### PR TITLE
Fix B-term crowdout

### DIFF
--- a/src/tests/test_work.py
+++ b/src/tests/test_work.py
@@ -66,4 +66,4 @@ def test_skim_work(data_dir):
     assert result[0]['bc_pmid_intersection'] == [34580748, 34578919]
 
     result = work.km_work_all_vs_all({'a_terms': ['cancer'], 'b_terms': ['carcinoma', 'downregulation'], 'c_terms': ['crop'], 'top_n': 1, 'ab_fet_threshold': 0.3, 'bc_fet_threshold': 0.3})
-    fff = 0
+    assert len(result) == 1

--- a/src/tests/test_work.py
+++ b/src/tests/test_work.py
@@ -64,3 +64,6 @@ def test_skim_work(data_dir):
     assert result[0]['bc_count'] == 2
     assert result[0]['ab_pmid_intersection'] == [34579798, 34579095, 34579733]
     assert result[0]['bc_pmid_intersection'] == [34580748, 34578919]
+
+    result = work.km_work_all_vs_all({'a_terms': ['cancer'], 'b_terms': ['carcinoma', 'downregulation'], 'c_terms': ['crop'], 'top_n': 1, 'ab_fet_threshold': 0.3, 'bc_fet_threshold': 0.3})
+    fff = 0

--- a/src/workers/work.py
+++ b/src/workers/work.py
@@ -122,7 +122,7 @@ def km_work_all_vs_all(json: dict):
             reverse=True)
 
         ab_results = ab_results[:top_n + 20]
-        
+
         # RAM efficiency. decache unneeded tokens/terms
         b_terms_used = set([ab_res['b_term'] for ab_res in ab_results])
         c_term_token_dict = _get_token_dict(c_terms)


### PR DESCRIPTION
sometimes high prediction score A-B pairs with no B-C pairs will crowd out lower-scoring A-B pairs that have B-C pairs. we want to ignore the former in favor of including the latter