### PR TITLE
Expose `iterations` on hypothesis_eval API

### DIFF
--- a/src/jobs/hypothesis_eval/job.py
+++ b/src/jobs/hypothesis_eval/job.py
@@ -69,6 +69,11 @@ def _run_skim_gpt(job_dir: str, params: HypothesisEvalJobParams) -> dict:
     config['GLOBAL_SETTINGS']['TOP_N_ARTICLES_MOST_CITED'] = params.top_n_articles_most_cited
     config['GLOBAL_SETTINGS']['TOP_N_ARTICLES_MOST_RECENT'] = params.top_n_articles_most_recent
     config['GLOBAL_SETTINGS']['POST_N'] = params.post_n
+    # iterations==1 is "no iteration loop, write to output/" (matches the
+    # legacy behaviour). >1 enables the worker's iteration loop, which writes
+    # to output/iteration_{i}/ — the result collector below recurses into
+    # those subdirs and tags each parsed result with its iteration index.
+    config['GLOBAL_SETTINGS']['iterations'] = params.iterations if params.iterations > 1 else False
     config['JOB_SPECIFIC_SETTINGS']['km_with_gpt']['censor_year_upper'] = params.censor_year_upper
     config['JOB_SPECIFIC_SETTINGS']['km_with_gpt']['censor_year_lower'] = params.censor_year_lower
     config['JOB_SPECIFIC_SETTINGS']['skim_with_gpt']['censor_year_upper'] = params.censor_year_upper
@@ -196,6 +201,8 @@ def _run_skim_gpt(job_dir: str, params: HypothesisEvalJobParams) -> dict:
     # Collect result JSON files from both possible output locations:
     #   - Triton success: written to job_dir root by run_relevance_pipeline
     #   - CHTC fallback:  written to job_dir/output/ by HTCondor transfer
+    # When iterations > 1 the worker writes to output/iteration_{i}/ — recurse
+    # so per-iteration JSONs are picked up.
     print("Processing results...")
     skip = {"config.json", "secrets.json"}
     result_files = [
@@ -204,7 +211,7 @@ def _run_skim_gpt(job_dir: str, params: HypothesisEvalJobParams) -> dict:
     ]
     output_dir = os.path.join(job_dir, "output")
     if os.path.exists(output_dir):
-        result_files.extend(glob(os.path.join(output_dir, "*.json")))
+        result_files.extend(glob(os.path.join(output_dir, "**", "*.json"), recursive=True))
 
     if not result_files:
         for dirpath, _, filenames in os.walk(job_dir):
@@ -215,10 +222,30 @@ def _run_skim_gpt(job_dir: str, params: HypothesisEvalJobParams) -> dict:
     print(f"Found {len(result_files)} result file(s): {', '.join(result_files)}")
     results = []
     for result_file in result_files:
-        results.extend(_parse_json_result(result_file))
+        iter_idx = _iteration_from_path(result_file)
+        for parsed in _parse_json_result(result_file):
+            if iter_idx is not None:
+                parsed['iteration'] = iter_idx
+            results.append(parsed)
 
     print(f"Results processed successfully. Job files are in {job_dir}")
     return results
+
+
+def _iteration_from_path(path: str) -> int | None:
+    """Extract the iteration index from a per-iteration result path.
+
+    The worker writes to ``output/iteration_{i}/…json`` when the iteration
+    loop is enabled. Returns ``None`` for files outside an ``iteration_*``
+    directory (i.e. the legacy single-run layout).
+    """
+    parent = os.path.basename(os.path.dirname(path))
+    if parent.startswith("iteration_"):
+        try:
+            return int(parent.split("_", 1)[1])
+        except ValueError:
+            return None
+    return None
 
 def _parse_json_result(json_result_file: str) -> list[dict]:
     parsed_results = []

--- a/src/jobs/hypothesis_eval/job.py
+++ b/src/jobs/hypothesis_eval/job.py
@@ -13,44 +13,92 @@ from src.jobs.job_util import report_log
 IMAGE_VERSION = os.environ.get("SKIMGPT_IMAGE", "2.0.1")
 SKIMGPT_IMAGE = f"docker://stewartlab/skimgpt:{IMAGE_VERSION}"
 
-def run_hypothesis_eval_job(params: HypothesisEvalJobParams) -> dict:
+PMID_KEYS = ("ab_pmid_intersection", "bc_pmid_intersection", "ac_pmid_intersection")
+ITERATION_PREFIX = "iteration_"
+
+
+def _compute_windows(lower: int, upper: int, increment: int | None) -> list[tuple[int, int]]:
+    """Non-overlapping windows of size `increment` tiling [lower, upper].
+
+    `increment=None` collapses to a single window covering the full range
+    (existing single-call behavior).
+    """
+    if increment is None:
+        return [(lower, upper)]
+    return [(s, min(s + increment - 1, upper)) for s in range(lower, upper + 1, increment)]
+
+
+def run_hypothesis_eval_job(params: HypothesisEvalJobParams) -> list[dict]:
     validate_params(params)
 
-    # create the job dir to store required files
     job = get_current_job()
     if not job:
         raise RuntimeError("Could not get current RQ job")
-    
+
     # note that this needs to be an absolute path because we change the CWD below.
     # TODO: this assumes a certain structure of the file system that is generally only true in the docker build.
-    temp_dir = os.path.join("/app", "_data", "jobs", "job-" + job.id)
-    os.makedirs(temp_dir, exist_ok=True)
+    base_dir = os.path.join("/app", "_data", "jobs", "job-" + job.id)
+    os.makedirs(base_dir, exist_ok=True)
 
-    # run the condor job
-    results = _run_skim_gpt(temp_dir, params)
-    return results
+    windows = _compute_windows(
+        params.censor_year_lower, params.censor_year_upper, params.censor_year_increment
+    )
 
-def _run_skim_gpt(job_dir: str, params: HypothesisEvalJobParams) -> dict:
+    if len(windows) == 1:
+        lo, hi = windows[0]
+        return _run_skim_gpt(base_dir, params, lo, hi)
+
+    print(f"Running hypothesis_eval over {len(windows)} window(s) of "
+          f"{params.censor_year_increment} year(s) each: {windows}")
+    all_results: list[dict] = []
+    for lo, hi in windows:
+        window_dir = os.path.join(base_dir, f"window_cy{hi}")
+        os.makedirs(window_dir, exist_ok=True)
+        print(f"--- window {lo}-{hi} -> {window_dir} ---")
+        window_results = _run_skim_gpt(window_dir, params, lo, hi)
+        for r in window_results:
+            r["censor_year_lower"] = lo
+            r["censor_year_upper"] = hi
+        all_results.extend(window_results)
+    return all_results
+
+
+def _run_skim_gpt(job_dir: str, params: HypothesisEvalJobParams,
+                  censor_year_lower: int, censor_year_upper: int) -> list[dict]:
     """Run skimgpt-relevance in a local Docker container (Triton-first, CHTC fallback).
 
     Creates the job files (config.json, data.tsv, files.txt, secrets.json) in
     job_dir, then runs the SKIMGPT_IMAGE as a sibling container.  The
     container tries Triton remote inference first; if Triton is unreachable it
     falls back to submitting an HTCondor GPU job internally.
+
+    Multi-window callers pass per-window bounds; user-supplied PMID lists are
+    cleared so kinderminer re-searches against the window's range.
     """
     
     # Get config template
     config = _get_config_template()
-    
+
     # Extract data and determine job type
-    data = params.data
     is_km = params.KM_hypothesis is not None
     is_skim = params.SKIM_hypotheses is not None
 
     if not (is_km or is_skim):
         raise FastKmException('job must be KM or SKiM')
-    
-    data = _populate_pmid_intersections(data, params.censor_year_lower, params.censor_year_upper)
+
+    # Per-window mode drops user-supplied PMID lists so kinderminer re-searches
+    # against each window's bounds. Shallow-copy each item; PMID lists are
+    # reassigned (not mutated) by _populate_pmid_intersections, so deepcopy is
+    # unnecessary.
+    if params.censor_year_increment is not None:
+        data = [{**item} for item in params.data]
+        for item in data:
+            for k in PMID_KEYS:
+                item.pop(k, None)
+    else:
+        data = params.data
+
+    data = _populate_pmid_intersections(data, censor_year_lower, censor_year_upper)
 
     if params.is_dch:
         config['JOB_TYPE'] = 'km_with_gpt'
@@ -69,15 +117,12 @@ def _run_skim_gpt(job_dir: str, params: HypothesisEvalJobParams) -> dict:
     config['GLOBAL_SETTINGS']['TOP_N_ARTICLES_MOST_CITED'] = params.top_n_articles_most_cited
     config['GLOBAL_SETTINGS']['TOP_N_ARTICLES_MOST_RECENT'] = params.top_n_articles_most_recent
     config['GLOBAL_SETTINGS']['POST_N'] = params.post_n
-    # iterations==1 is "no iteration loop, write to output/" (matches the
-    # legacy behaviour). >1 enables the worker's iteration loop, which writes
-    # to output/iteration_{i}/ — the result collector below recurses into
-    # those subdirs and tags each parsed result with its iteration index.
+    # SKiM-GPT contract: int N>1 enables the iteration loop (writes to
+    # output/iteration_{i}/); False disables it (writes flat to output/).
     config['GLOBAL_SETTINGS']['iterations'] = params.iterations if params.iterations > 1 else False
-    config['JOB_SPECIFIC_SETTINGS']['km_with_gpt']['censor_year_upper'] = params.censor_year_upper
-    config['JOB_SPECIFIC_SETTINGS']['km_with_gpt']['censor_year_lower'] = params.censor_year_lower
-    config['JOB_SPECIFIC_SETTINGS']['skim_with_gpt']['censor_year_upper'] = params.censor_year_upper
-    config['JOB_SPECIFIC_SETTINGS']['skim_with_gpt']['censor_year_lower'] = params.censor_year_lower
+    for jt in ('km_with_gpt', 'skim_with_gpt'):
+        config['JOB_SPECIFIC_SETTINGS'][jt]['censor_year_lower'] = censor_year_lower
+        config['JOB_SPECIFIC_SETTINGS'][jt]['censor_year_upper'] = censor_year_upper
 
     # Set up secrets
     secrets = {
@@ -201,20 +246,35 @@ def _run_skim_gpt(job_dir: str, params: HypothesisEvalJobParams) -> dict:
     if exit_code != 0:
         raise RuntimeError(f"skimgpt-relevance container exited with code {exit_code}")
 
-    # Collect result JSON files from both possible output locations:
-    #   - Triton success: written to job_dir root by run_relevance_pipeline
-    #   - CHTC fallback:  written to job_dir/output/ by HTCondor transfer
-    # When iterations > 1 the worker writes to output/iteration_{i}/ — recurse
-    # so per-iteration JSONs are picked up.
     print("Processing results...")
+    results = _collect_results(job_dir, expected_iterations=params.iterations)
+    print(f"Results processed successfully. Job files are in {job_dir}")
+    return results
+
+
+def _collect_results(job_dir: str, expected_iterations: int = 1) -> list[dict]:
+    """Find, parse, and tag JSON result files from a SKiM-GPT run.
+
+    Triton writes flat to ``job_dir/*.json``; CHTC fallback writes under
+    ``job_dir/output/`` (recursed; iteration_N subdirs may be present).
+    Every result is tagged ``iteration: N`` (1 for single-pass) for a stable
+    consumer shape. When ``expected_iterations > 1``, warns if any expected
+    index is missing — catches silent worker failures.
+    """
     skip = {"config.json", "secrets.json"}
+    debug_segment = os.sep + "debug" + os.sep
     result_files = [
         f for f in glob(os.path.join(job_dir, "*.json"))
         if os.path.basename(f) not in skip
     ]
     output_dir = os.path.join(job_dir, "output")
     if os.path.exists(output_dir):
-        result_files.extend(glob(os.path.join(output_dir, "**", "*.json"), recursive=True))
+        # skimgpt's organize_output puts intermediate files under output/debug/;
+        # exclude that subtree so we don't parse non-result JSONs as results.
+        result_files.extend(
+            f for f in glob(os.path.join(output_dir, "**", "*.json"), recursive=True)
+            if debug_segment not in f
+        )
 
     if not result_files:
         for dirpath, _, filenames in os.walk(job_dir):
@@ -227,27 +287,31 @@ def _run_skim_gpt(job_dir: str, params: HypothesisEvalJobParams) -> dict:
     for result_file in result_files:
         iter_idx = _iteration_from_path(result_file)
         for parsed in _parse_json_result(result_file):
-            if iter_idx is not None:
-                parsed['iteration'] = iter_idx
+            parsed['iteration'] = iter_idx if iter_idx is not None else 1
             results.append(parsed)
 
-    print(f"Results processed successfully. Job files are in {job_dir}")
+    if expected_iterations > 1:
+        seen = {r['iteration'] for r in results}
+        missing = set(range(1, expected_iterations + 1)) - seen
+        if missing:
+            print(f"WARNING: missing results for iteration(s) {sorted(missing)}; "
+                  f"expected {expected_iterations} iterations but only saw {sorted(seen)}.")
+
     return results
 
 
 def _iteration_from_path(path: str) -> int | None:
-    """Extract the iteration index from a per-iteration result path.
+    """Extract iteration index from any ``iteration_N`` ancestor (innermost wins).
 
-    The worker writes to ``output/iteration_{i}/…json`` when the iteration
-    loop is enabled. Returns ``None`` for files outside an ``iteration_*``
-    directory (i.e. the legacy single-run layout).
+    Walks all ancestors because skimgpt's ``organize_output`` may nest
+    ``iteration_*/`` under ``results/``. Raises ``ValueError`` on an
+    unparseable suffix so worker path-format drift fails loudly instead of
+    silently dropping the tag.
     """
-    parent = os.path.basename(os.path.dirname(path))
-    if parent.startswith("iteration_"):
-        try:
-            return int(parent.split("_", 1)[1])
-        except ValueError:
-            return None
+    parts = os.path.dirname(path).split(os.sep)
+    for part in reversed(parts):
+        if part.startswith(ITERATION_PREFIX):
+            return int(part[len(ITERATION_PREFIX):])
     return None
 
 def _parse_json_result(json_result_file: str) -> list[dict]:

--- a/src/jobs/hypothesis_eval/job.py
+++ b/src/jobs/hypothesis_eval/job.py
@@ -1,6 +1,5 @@
 import os
 import json
-from glob import glob
 import subprocess
 from rq import get_current_job
 from src.fast_km_exception import FastKmException
@@ -255,26 +254,36 @@ def _run_skim_gpt(job_dir: str, params: HypothesisEvalJobParams,
 def _collect_results(job_dir: str, expected_iterations: int = 1) -> list[dict]:
     """Find, parse, and tag JSON result files from a SKiM-GPT run.
 
-    Triton writes flat to ``job_dir/*.json``; CHTC fallback writes under
-    ``job_dir/output/`` (recursed; iteration_N subdirs may be present).
-    Every result is tagged ``iteration: N`` (1 for single-pass) for a stable
-    consumer shape. When ``expected_iterations > 1``, warns if any expected
-    index is missing — catches silent worker failures.
+    Walks ``job_dir`` recursively and treats every ``.json`` as a result,
+    excluding two well-known noise sources:
+      * ``config.json`` / ``secrets.json`` at the job root (run metadata).
+      * Anything under a ``debug/`` directory (skimgpt's intermediate JSONs).
+
+    Layout-agnostic by design. skimgpt has historically placed results under
+    ``output/`` for single-pass runs and ``iteration_N/`` for multi-iteration
+    runs, and the iteration loop and CHTC fallback don't agree on which.
+    Tagging is path-based via ``_iteration_from_path``, which finds the
+    innermost ``iteration_N`` ancestor — so a file lands at the correct
+    iteration regardless of where in the tree skimgpt drops it. New layouts
+    Just Work as long as the convention "iteration_N is somewhere in the
+    path; debug subtrees are noise" holds.
+
+    When ``expected_iterations > 1``, warns if any expected index is missing
+    — catches silent worker failures.
     """
-    skip = {"config.json", "secrets.json"}
-    debug_segment = os.sep + "debug" + os.sep
-    result_files = [
-        f for f in glob(os.path.join(job_dir, "*.json"))
-        if os.path.basename(f) not in skip
-    ]
-    output_dir = os.path.join(job_dir, "output")
-    if os.path.exists(output_dir):
-        # skimgpt's organize_output puts intermediate files under output/debug/;
-        # exclude that subtree so we don't parse non-result JSONs as results.
-        result_files.extend(
-            f for f in glob(os.path.join(output_dir, "**", "*.json"), recursive=True)
-            if debug_segment not in f
-        )
+    skip_at_root = {"config.json", "secrets.json"}
+    job_root = os.path.normpath(job_dir)
+    result_files = []
+    for dirpath, dirnames, filenames in os.walk(job_dir):
+        # Prune debug subtrees from the traversal entirely.
+        dirnames[:] = [d for d in dirnames if d != "debug"]
+        is_root = os.path.normpath(dirpath) == job_root
+        for fn in filenames:
+            if not fn.endswith(".json"):
+                continue
+            if is_root and fn in skip_at_root:
+                continue
+            result_files.append(os.path.join(dirpath, fn))
 
     if not result_files:
         for dirpath, _, filenames in os.walk(job_dir):

--- a/src/jobs/hypothesis_eval/params.py
+++ b/src/jobs/hypothesis_eval/params.py
@@ -13,6 +13,7 @@ class HypothesisEvalJobParams(BaseModel):
     post_n: int =                     Field(5,                                       description=".")
     censor_year_lower: int =          Field(MIN_CENSOR_YEAR,                         description="Lower bound of publication year for article censoring (inclusive). Ignored if a PMID list is supplied.")
     censor_year_upper: int =          Field(MAX_CENSOR_YEAR,   alias="censor_year",  description="Upper bound of publication year for article censoring (inclusive). Ignored if a PMID list is supplied.")
+    iterations: int =                 Field(1,                 ge=1, le=10,         description="Run the LLM scoring N independent times. Each iteration produces its own score; useful for capturing nondeterminism on DCH jobs. Default 1 (single run).")
     id: str | None =                  Field(None,                                    description="Optional job ID. If not provided, an ID will be generated.")
 
 def validate_params(params: HypothesisEvalJobParams) -> None:

--- a/src/jobs/hypothesis_eval/params.py
+++ b/src/jobs/hypothesis_eval/params.py
@@ -8,6 +8,7 @@ MAX_ITERATIONS = 10
 
 
 class HypothesisEvalJobParams(BaseModel):
+
     data: list[dict] =                Field(...,                                     description="KM/SKiM results to use to evaluate the hypotheses.")
     KM_hypothesis: str | None =       Field(None,                                    description="Hypothesis to evaluate using KM results.")
     SKIM_hypotheses: dict | None =    Field(None,                                    description="Hypotheses to evaluate using SKiM results.")
@@ -17,7 +18,7 @@ class HypothesisEvalJobParams(BaseModel):
     top_n_articles_most_recent: int = Field(5,                                       description="Number of most recent articles to include in the context provided to the LLM.")
     post_n: int =                     Field(5,                                       description=".")
     censor_year_lower: int =          Field(MIN_CENSOR_YEAR,                         description="Lower bound of publication year for article censoring (inclusive). Ignored if a PMID list is supplied.")
-    censor_year_upper: int =          Field(MAX_CENSOR_YEAR,   alias="censor_year",  description="Upper bound of publication year for article censoring (inclusive). Ignored if a PMID list is supplied.")
+    censor_year_upper: int =          Field(MAX_CENSOR_YEAR,                         description="Upper bound of publication year for article censoring (inclusive). Ignored if a PMID list is supplied.")
     censor_year_increment: int | None = Field(None,            ge=1,                 description="If set, split [censor_year_lower, censor_year_upper] into non-overlapping windows of this many years and run the hypothesis evaluation per window. Forces re-fetching of PMID intersections per window (any user-supplied *_pmid_intersection lists are discarded). Default None (single window covering the full range).")
     iterations: int =                 Field(1,    ge=1, le=MAX_ITERATIONS,         description=f"Run the LLM scoring N independent times. Each iteration produces its own score; useful for capturing LLM nondeterminism. Capped at {MAX_ITERATIONS} to bound API cost. Default 1 (single run).")
     id: str | None =                  Field(None,                                    description="Optional job ID. If not provided, an ID will be generated.")

--- a/src/jobs/hypothesis_eval/params.py
+++ b/src/jobs/hypothesis_eval/params.py
@@ -2,6 +2,11 @@ from pydantic import BaseModel, Field
 from src.fast_km_exception import FastKmException
 from src.global_vars import MAX_CENSOR_YEAR, MIN_CENSOR_YEAR
 
+# Cap iterations to bound LLM API cost — each iteration is a full re-scoring
+# pass against the same context, so cost scales linearly with this value.
+MAX_ITERATIONS = 10
+
+
 class HypothesisEvalJobParams(BaseModel):
     data: list[dict] =                Field(...,                                     description="KM/SKiM results to use to evaluate the hypotheses.")
     KM_hypothesis: str | None =       Field(None,                                    description="Hypothesis to evaluate using KM results.")
@@ -13,7 +18,8 @@ class HypothesisEvalJobParams(BaseModel):
     post_n: int =                     Field(5,                                       description=".")
     censor_year_lower: int =          Field(MIN_CENSOR_YEAR,                         description="Lower bound of publication year for article censoring (inclusive). Ignored if a PMID list is supplied.")
     censor_year_upper: int =          Field(MAX_CENSOR_YEAR,   alias="censor_year",  description="Upper bound of publication year for article censoring (inclusive). Ignored if a PMID list is supplied.")
-    iterations: int =                 Field(1,                 ge=1, le=10,         description="Run the LLM scoring N independent times. Each iteration produces its own score; useful for capturing nondeterminism on DCH jobs. Default 1 (single run).")
+    censor_year_increment: int | None = Field(None,            ge=1,                 description="If set, split [censor_year_lower, censor_year_upper] into non-overlapping windows of this many years and run the hypothesis evaluation per window. Forces re-fetching of PMID intersections per window (any user-supplied *_pmid_intersection lists are discarded). Default None (single window covering the full range).")
+    iterations: int =                 Field(1,    ge=1, le=MAX_ITERATIONS,         description=f"Run the LLM scoring N independent times. Each iteration produces its own score; useful for capturing LLM nondeterminism. Capped at {MAX_ITERATIONS} to bound API cost. Default 1 (single run).")
     id: str | None =                  Field(None,                                    description="Optional job ID. If not provided, an ID will be generated.")
 
 def validate_params(params: HypothesisEvalJobParams) -> None:

--- a/tests/test_hypothesis_eval.py
+++ b/tests/test_hypothesis_eval.py
@@ -1,0 +1,68 @@
+"""Tests for hypothesis_eval params + result-collection helpers.
+
+Excludes the full ``run_hypothesis_eval_job`` flow (needs apptainer +
+HTCondor token + skimgpt image). Those still get integration coverage in
+the real environment.
+"""
+import os
+
+import pytest
+from pydantic import ValidationError
+
+from src.jobs.hypothesis_eval.job import _iteration_from_path
+from src.jobs.hypothesis_eval.params import HypothesisEvalJobParams
+
+
+# --- iterations param --------------------------------------------------------
+
+def _km_dch_payload(**overrides):
+    """Minimal valid DCH payload, with overrides merged in."""
+    payload = {
+        "data": [
+            {"a_term": "diseaseX", "b_term": "geneA", "ab_pmid_intersection": []},
+            {"a_term": "diseaseX", "b_term": "geneB", "ab_pmid_intersection": []},
+        ],
+        "KM_hypothesis": "{a_term} is caused by {b_term}",
+        "is_dch": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_iterations_defaults_to_one():
+    p = HypothesisEvalJobParams(**_km_dch_payload())
+    assert p.iterations == 1
+
+
+def test_iterations_accepts_in_range():
+    for n in (1, 3, 10):
+        p = HypothesisEvalJobParams(**_km_dch_payload(iterations=n))
+        assert p.iterations == n
+
+
+def test_iterations_rejects_zero_or_negative():
+    for bad in (0, -1, -10):
+        with pytest.raises(ValidationError):
+            HypothesisEvalJobParams(**_km_dch_payload(iterations=bad))
+
+
+def test_iterations_rejects_above_cap():
+    with pytest.raises(ValidationError):
+        HypothesisEvalJobParams(**_km_dch_payload(iterations=11))
+
+
+# --- _iteration_from_path ----------------------------------------------------
+
+def test_iteration_from_path_extracts_index():
+    p = os.path.join("/job/output", "iteration_3", "diseaseX_geneA_km.json")
+    assert _iteration_from_path(p) == 3
+
+
+def test_iteration_from_path_returns_none_for_flat_layout():
+    p = os.path.join("/job/output", "diseaseX_geneA_km.json")
+    assert _iteration_from_path(p) is None
+
+
+def test_iteration_from_path_returns_none_for_unparseable_index():
+    p = os.path.join("/job/output", "iteration_abc", "x.json")
+    assert _iteration_from_path(p) is None

--- a/tests/test_hypothesis_eval.py
+++ b/tests/test_hypothesis_eval.py
@@ -4,12 +4,17 @@ Excludes the full ``run_hypothesis_eval_job`` flow (needs apptainer +
 HTCondor token + skimgpt image). Those still get integration coverage in
 the real environment.
 """
+import json
 import os
 
 import pytest
 from pydantic import ValidationError
 
-from src.jobs.hypothesis_eval.job import _iteration_from_path
+from src.jobs.hypothesis_eval.job import (
+    _collect_results,
+    _compute_windows,
+    _iteration_from_path,
+)
 from src.jobs.hypothesis_eval.params import HypothesisEvalJobParams
 
 
@@ -51,6 +56,48 @@ def test_iterations_rejects_above_cap():
         HypothesisEvalJobParams(**_km_dch_payload(iterations=11))
 
 
+# --- censor_year_increment param --------------------------------------------
+
+def test_increment_defaults_to_none():
+    p = HypothesisEvalJobParams(**_km_dch_payload())
+    assert p.censor_year_increment is None
+
+
+def test_increment_accepts_positive():
+    for n in (1, 2, 5):
+        p = HypothesisEvalJobParams(**_km_dch_payload(censor_year_increment=n))
+        assert p.censor_year_increment == n
+
+
+def test_increment_rejects_zero_or_negative():
+    for bad in (0, -1):
+        with pytest.raises(ValidationError):
+            HypothesisEvalJobParams(**_km_dch_payload(censor_year_increment=bad))
+
+
+# --- _compute_windows --------------------------------------------------------
+
+def test_windows_none_increment_is_single_window():
+    assert _compute_windows(2020, 2025, None) == [(2020, 2025)]
+
+
+def test_windows_inc_one_is_per_year():
+    assert _compute_windows(2020, 2022, 1) == [(2020, 2020), (2021, 2021), (2022, 2022)]
+
+
+def test_windows_inc_two_tiles_evenly():
+    assert _compute_windows(2020, 2025, 2) == [(2020, 2021), (2022, 2023), (2024, 2025)]
+
+
+def test_windows_inc_two_clamps_uneven_tail():
+    assert _compute_windows(2020, 2024, 2) == [(2020, 2021), (2022, 2023), (2024, 2024)]
+
+
+def test_windows_single_year_range():
+    assert _compute_windows(2020, 2020, 1) == [(2020, 2020)]
+    assert _compute_windows(2020, 2020, 5) == [(2020, 2020)]
+
+
 # --- _iteration_from_path ----------------------------------------------------
 
 def test_iteration_from_path_extracts_index():
@@ -63,6 +110,73 @@ def test_iteration_from_path_returns_none_for_flat_layout():
     assert _iteration_from_path(p) is None
 
 
-def test_iteration_from_path_returns_none_for_unparseable_index():
+def test_iteration_from_path_raises_for_unparseable_index():
     p = os.path.join("/job/output", "iteration_abc", "x.json")
-    assert _iteration_from_path(p) is None
+    with pytest.raises(ValueError):
+        _iteration_from_path(p)
+
+
+def test_iteration_from_path_handles_nested_layout():
+    p = os.path.join("/job/output", "results", "iteration_2", "diseaseX_geneA_km.json")
+    assert _iteration_from_path(p) == 2
+
+
+# --- _collect_results --------------------------------------------------------
+
+def _write_result_json(path, payload):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(payload, f)
+
+
+def _km_result_payload(a="diseaseX", b="geneA"):
+    return {"A_B_Relationship": {"a_term": a, "b_term": b, "Result": "ok"}}
+
+
+def test_collect_results_tags_single_pass_with_iteration_one(tmp_path):
+    _write_result_json(str(tmp_path / "diseaseX_geneA_km.json"), _km_result_payload())
+    results = _collect_results(str(tmp_path), expected_iterations=1)
+    assert len(results) == 1
+    assert results[0]["iteration"] == 1
+
+
+def test_collect_results_tags_multi_iteration(tmp_path):
+    for i in (1, 2, 3):
+        _write_result_json(
+            str(tmp_path / "output" / f"iteration_{i}" / "diseaseX_geneA_km.json"),
+            _km_result_payload(),
+        )
+    results = _collect_results(str(tmp_path), expected_iterations=3)
+    assert sorted(r["iteration"] for r in results) == [1, 2, 3]
+
+
+def test_collect_results_warns_on_missing_iteration(tmp_path, capsys):
+    for i in (1, 3):
+        _write_result_json(
+            str(tmp_path / "output" / f"iteration_{i}" / "diseaseX_geneA_km.json"),
+            _km_result_payload(),
+        )
+    _collect_results(str(tmp_path), expected_iterations=3)
+    out = capsys.readouterr().out
+    assert "WARNING" in out
+    assert "[2]" in out  # the missing iteration
+
+
+def test_collect_results_raises_when_no_files(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        _collect_results(str(tmp_path), expected_iterations=1)
+
+
+def test_collect_results_skips_config_and_secrets(tmp_path):
+    _write_result_json(str(tmp_path / "config.json"), {"x": 1})
+    _write_result_json(str(tmp_path / "secrets.json"), {"x": 1})
+    _write_result_json(str(tmp_path / "diseaseX_geneA_km.json"), _km_result_payload())
+    results = _collect_results(str(tmp_path), expected_iterations=1)
+    assert len(results) == 1
+
+
+def test_collect_results_skips_debug_subtree(tmp_path):
+    _write_result_json(str(tmp_path / "output" / "diseaseX_geneA_km.json"), _km_result_payload())
+    _write_result_json(str(tmp_path / "output" / "debug" / "trace.json"), {"trace": "noise"})
+    results = _collect_results(str(tmp_path), expected_iterations=1)
+    assert len(results) == 1


### PR DESCRIPTION
DCH and KM hypothesis-eval jobs run the LLM once and return a single score, but LLM scoring is non-deterministic. The downstream skimgpt worker (kmGPT/src/relevance.py) already supports an `iterations` setting that runs the scoring N times and writes per-iteration results into `output/iteration_{i}/`; the value just wasn't reachable from the API because the static config template hard-coded it to `False` and the result collector only globbed the flat `output/` directory.

Three small changes:

  * params.py: add `iterations: int = Field(1, ge=1, le=10, ...)` to HypothesisEvalJobParams. Default 1 keeps existing callers' behaviour bit-identical (single run, results written to `output/`).
  * job.py: inject `params.iterations` into `GLOBAL_SETTINGS.iterations`. We pass `False` when iterations==1 to match the worker's no-loop branch exactly; values >1 enable the per-iteration output layout.
  * job.py: switch the post-run result glob to recurse so per-iteration JSONs under `output/iteration_*/` are picked up. Each parsed result is tagged with `iteration: N` derived from its parent directory, so consumers can distinguish runs without filename parsing.

Tests cover the param defaults / range and the iteration-extraction helper. The full run-job flow still requires apptainer + HTCondor + the skimgpt image and is exercised in the real environment.